### PR TITLE
[WIP] [security] Fix Erlang CVEs 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,38 @@
-# Build stage 0
-FROM erlang:22.3.4-slim
+##
+# Build stage
+FROM --platform=linux/amd64 ubuntu:22.04 AS build
 
 # Install some libs
-RUN apt-get update && \
-      apt-get install --no-install-recommends -y libstdc++6 openssl libtinfo5 && \
-      rm -rf /var/lib/apt/lists/* 
+RUN apt-get update -yqq && \
+    apt-get install -yqq cmake clang libtool gcc git curl libssl-dev \
+    build-essential automake autoconf libncurses5-dev elixir iputils-ping \
+    erlang-base erlang-public-key erlang-asn1 erlang-ssl erlang-dev erlang-inets \
+    erlang-eunit erlang-common-test rebar3
 
 # Set working directory
 WORKDIR /opt/thepower
 
-RUN mkdir -p /opt/thepower/db
-
-# Copy Power_node application
 COPY . .
 
-# Set symlink
-RUN ln -s /usr/bin/openssl /usr/local/bin/openssl
+# Build binaries
+RUN rebar3 compile
+RUN rebar3 release
+RUN rebar3 tar
 
-# Expose relevant ports
-EXPOSE 49841
-EXPOSE 29841
+RUN mkdir -p build
 
-ENTRYPOINT [ "./bin/thepower" ] 
+# TODO: Copy only necessary resources for runtime: bin lib releases
+RUN cp -r bin build/
 
-CMD ["foreground"]
+##
+# Runtime stage: image for tpnode binary
+FROM erlang:22.3.4-slim AS runtime
+
+# Set working directory
+WORKDIR /opt/thepower
+
+# Copy tpnode binaries and config: bin, lib and releases
+COPY --from=build /opt/thepower/build/ .
+
+# TODO: confirm the behaviour of the binary to choose the accurate entrypoint
+ENTRYPOINT ["./bin/thepower"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,9 @@
 FROM erlang:22.3.4-slim
 
 # Install some libs
-RUN apt-get update -y && apt-get install -y \
-      libstdc++6 openssl libtinfo5 
+RUN apt-get update && \
+      apt-get install --no-install-recommends -y libstdc++6 openssl libtinfo5 && \
+      rm -rf /var/lib/apt/lists/* 
 
 # Set working directory
 WORKDIR /opt/thepower

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage 0
-FROM erlang:22
+FROM erlang:22.3.4-slim
 
 # Install some libs
 RUN apt-get update -y && apt-get install -y \


### PR DESCRIPTION
# Summary of changes

## Issue
When scanning tpnode with Docker scout, we find 3 critical and 29 high severity CVEs, which is originated from Erlang 22 image.

## Solution
To resolve the issue, we upgrade erlang from 22 to 22.3.4-slim.

## Results
We succeed in security by fixing CVEs, but we gained in size from 146MB to 260MB, which we can fix in another PR is important.

## Other information and links
The fix is based on the newest image of [erlang](https://hub.docker.com/_/erlang/tags) that is free of critical CVEs.

## Change checklist

 - [ ] I have performed a self-review of my code.
 - [ ] I have added tests that prove my fix is effective.
 - [ ] I made sure the CHANGELOG is up-to-date (We need to create one).